### PR TITLE
Update vergen-gix build dependency and pin vergen version

### DIFF
--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -20,7 +20,8 @@ clap = { version = "4.5", features = ["derive", "error-context"] }
 owo-colors = "4.1"
 
 [build-dependencies]
-vergen-gix = { version = "1.0", features = ["build", "cargo", "rustc", "si"] }
+vergen-gix = { version = "9.1.0", features = ["build", "cargo", "rustc", "si"] }
+vergen = "9.1.0"
 
 [lints]
 workspace = true


### PR DESCRIPTION
Building would fail probably due to differences between the newest vergen versions and the pinned vergen-gix version, this change brings vergen-gix up to date with the newest version and pins vergen so they won't fall out of sync again. My tongue will end up in a knot if I have to say vergen version again.